### PR TITLE
Better client protocol detection.

### DIFF
--- a/node_flv_session.js
+++ b/node_flv_session.js
@@ -30,7 +30,7 @@ class NodeFlvSession extends EventEmitter {
     this.on('play', this.onPlay);
     this.on('publish', this.onPublish);
 
-    if (req.headers.upgrade === 'websocket') {
+    if (req.nmsConnectionType === 'ws') {
       this.res.on('message', this.onReqData.bind(this));
       this.res.on('close', this.onReqClose.bind(this));
       this.res.on('error', this.onReqError.bind(this));

--- a/node_http_server.js
+++ b/node_http_server.js
@@ -36,6 +36,7 @@ class NodeHttpServer {
           res.setHeader('Access-Control-Allow-Origin', this.config.http.allow_origin);
           next();
         } else {
+          req.nmsConnectionType = 'http';
           this.onConnect(req, res);
         }
       }
@@ -77,6 +78,7 @@ class NodeHttpServer {
     this.wsServer = new WebSocket.Server({ server: this.httpServer });
 
     this.wsServer.on('connection', (ws, req) => {
+      req.nmsConnectionType = 'ws';
       this.onConnect(req, ws);
     });
 
@@ -90,6 +92,7 @@ class NodeHttpServer {
     this.wssServer = new WebSocket.Server({ server: this.httpsServer });
 
     this.wssServer.on('connection', (ws, req) => {
+      req.nmsConnectionType = 'ws';
       this.onConnect(req, ws);
     });
 


### PR DESCRIPTION
This pull request fixes this issue.
https://github.com/illuspas/Node-Media-Server/issues/21
I encountered this error a lot while server was running in production.
After some investigation I found the core of the problem.
Some devices, for some reason, send upgrade header as "Websocket" and not as "websocket", as you expect. So when the time comes, server thinks it was a http connection, but in reality that was a websocket connection, so all subsequent logic is broken. Generally, I think it's really bad to trust client data for server logic.
This fix adds a property to the request so later down the line we can be sure that we're dealing with the right type of connection.