### PR TITLE
Socket events fix.

### DIFF
--- a/node_rtmp_session.js
+++ b/node_rtmp_session.js
@@ -299,10 +299,10 @@ class NodeRtmpSession extends EventEmitter {
       this.pingInterval = null;
     }
     this.nodeEvent.emit('doneConnect', this.id, this.connectCmdObj);
+    this.socket.end();
     this.socket.removeAllListeners('data');
     this.socket.removeAllListeners('close');
     this.socket.removeAllListeners('error');
-    this.socket.end();
     this.sessions.delete(this.id);
     this.idlePlayers = null;
     this.publishers = null;


### PR DESCRIPTION
Correct me if I'm wrong, but if there's an error when you execute end() on the socket, it will crash the server cause there's no more events that will catch the error.
I'm not sure if that's the case, but there were some weird errors that crashed the server that were connected to the rtmp socket. That crash appeared right after someone disconnected. And since this is the only place that I could find that could cause errors to bubble up with the socket I think it's pretty safe to assume that that's the problematic place.