### PR TITLE
Events fix.

### DIFF
--- a/node_rtmp_session.js
+++ b/node_rtmp_session.js
@@ -343,9 +343,6 @@ class NodeRtmpSession extends EventEmitter {
     }
     this.nodeEvent.emit('doneConnect', this.id, this.connectCmdObj);
     this.socket.end();
-    this.socket.removeAllListeners('data');
-    this.socket.removeAllListeners('close');
-    this.socket.removeAllListeners('error');
     this.sessions.delete(this.id);
     this.idlePlayers = null;
     this.publishers = null;

--- a/node_rtmp_session.js
+++ b/node_rtmp_session.js
@@ -343,6 +343,8 @@ class NodeRtmpSession extends EventEmitter {
     }
     this.nodeEvent.emit('doneConnect', this.id, this.connectCmdObj);
     this.socket.end();
+    this.socket.removeAllListeners('data');
+    this.socket.removeAllListeners('close');
     this.sessions.delete(this.id);
     this.idlePlayers = null;
     this.publishers = null;


### PR DESCRIPTION
This should fix this error. https://github.com/illuspas/Node-Media-Server/issues/32
Basically, if you're going to deference the session and it's socket, you don't need to manually remove events, garbage collector will do it for you, as far as I know.
But anyway, after some tests I found out the true reason of the crash. As stated in the issue, crash only happens if the client can't keep up with the stream. So I put some console logs before every socket write and found out both places where it gets called right before the crash. And at this point in time of the code lifecycle, session is already closed, the socket is closed and all event listeners are removed. So this is not really a fix, just a workaround. Real fix would entail finding out the real reason why these sections of the code even get called.
Here are these places.
https://github.com/illuspas/Node-Media-Server/blob/0d5711334776763c6416e8a55569835e6162843e/node_rtmp_session.js#L603
https://github.com/illuspas/Node-Media-Server/blob/0d5711334776763c6416e8a55569835e6162843e/node_rtmp_session.js#L660