### PR TITLE
create a third type of NodeFlvSession, one that sends the flv to a Node stream

### DIFF
--- a/api/controllers/streams.js
+++ b/api/controllers/streams.js
@@ -61,6 +61,14 @@ function getStreams(req, res, next) {
               break;
             }
             case 'NodeFlvSession': {
+              let protocol;
+              if (session.TAG === 'websocket-flv') {
+                protocol = 'ws';
+              } else if (session.TAG === 'stream-flv') {
+                protocol = 'stream';
+              } else {
+                protocol = 'http';
+              }
               stats[app][stream]['subscribers'].push({
                 app: app,
                 stream: stream,
@@ -68,7 +76,7 @@ function getStreams(req, res, next) {
                 connectCreated: session.connectTime,
                 bytes: session.req.connection.bytesWritten,
                 ip: session.req.connection.remoteAddress,
-                protocol: session.TAG === 'websocket-flv' ? 'ws' : 'http'
+                protocol: protocol
               });
 
               break;

--- a/app.js
+++ b/app.js
@@ -1,3 +1,6 @@
+const fs = require('fs');
+const path = require('path');
+
 const { NodeMediaServer } = require('./index');
 
 const config = {
@@ -30,7 +33,7 @@ const config = {
 };
 
 
-let nms = new NodeMediaServer(config)
+let nms = new NodeMediaServer(config);
 nms.run();
 
 nms.on('preConnect', (id, args) => {
@@ -51,6 +54,8 @@ nms.on('prePublish', (id, StreamPath, args) => {
   console.log('[NodeEvent on prePublish]', `id=${id} StreamPath=${StreamPath} args=${JSON.stringify(args)}`);
   // let session = nms.getSession(id);
   // session.reject();
+  const fileStream = fs.createWriteStream('./' + path.basename(StreamPath) + '.flv');
+  nms.saveFlvStream(StreamPath, fileStream);
 });
 
 nms.on('postPublish', (id, StreamPath, args) => {
@@ -74,4 +79,3 @@ nms.on('postPlay', (id, StreamPath, args) => {
 nms.on('donePlay', (id, StreamPath, args) => {
   console.log('[NodeEvent on donePlay]', `id=${id} StreamPath=${StreamPath} args=${JSON.stringify(args)}`);
 });
-


### PR DESCRIPTION
Instead of a transcode of ffmpeg connecting back and playing, this allows a one to save an incoming flv to an arbitrary node stream.

@illuspas this is rebased on top of current master, with merge problems fixed. I also addressed your issues on the previous PRs. Thanks.