### PR TITLE
Disable appending name to push stream

### DIFF
--- a/node_relay_server.js
+++ b/node_relay_server.js
@@ -158,7 +158,7 @@ class NodeRelayServer {
         let hasApp = conf.edge.match(/rtmp:\/\/([^\/]+)\/([^\/]+)/);
         conf.ffmpeg = this.config.relay.ffmpeg;
         conf.inPath = `rtmp://127.0.0.1:${this.config.rtmp.port}${streamPath}`;
-        conf.ouPath = hasApp ? `${conf.edge}/${stream}` : `${conf.edge}${streamPath}`;
+        conf.ouPath = conf.appendName === false ? conf.edge : (hasApp ? `${conf.edge}/${stream}` : `${conf.edge}${streamPath}`);
         let session = new NodeRelaySession(conf);
         session.id = id;
         session.on('end', (id) => {


### PR DESCRIPTION
With this PR you can disable automatic name appending to the output URL, for use with different stream services where you already set the name in the URL.

    relay: {
        ffmpeg: "path/to/ffmpeg",
        tasks: [{
            app: "live",
            mode: "push",
            edge: "FULL RTMP URL THAT DON'T HAS TO BE MODIFIED",
            appendName: false
        }]
    }