### PR TITLE
Allow multiple tasks for the same stream and keep relay active when closes unexpectedly

### DIFF
--- a/node_relay_session.js
+++ b/node_relay_session.js
@@ -48,12 +48,29 @@ class NodeRelaySession extends EventEmitter {
 
     this.ffmpeg_exec.on('close', (code) => {
       Logger.log('[Relay end] id=', this.id);
-      this.emit('end', this.id);
+      this.ffmpeg_exec = null;
+      if (!this._ended) {
+        this._runtimeout = setTimeout(() => {
+          this._runtimeout = null;
+          this.run();
+        }, 1000);
+      } else {
+        this.emit('end', this.id);
+      }
     });
   }
 
   end() {
-    this.ffmpeg_exec.kill();
+    this._ended = true;
+    if (this._runtimeout != null) {
+      clearTimeout(this._runtimeout);
+      this._runtimeout = null;
+    }
+    if (this.ffmpeg_exec) {
+      this.ffmpeg_exec.kill();
+    } else {
+      this.emit('end', this.id);
+    }
   }
 }
 


### PR DESCRIPTION
Now it only allows one task for the same stream, which is kinda sad.

With this patch, multiple tasks for the same stream are allowed (push to 2 destinations for the same stream, for example).

Also, when a ffmpeg task closes unexpectedly, it will autorestart (maybe lost connection with the destination server for a while, for example).