### PR TITLE
Bug Fix: 'undefined' Errors Thrown When Calling 'stop()'

### DIFF
--- a/node_media_server.js
+++ b/node_media_server.js
@@ -88,9 +88,6 @@ class NodeMediaServer {
     if (this.nls) {
       this.nls.stop();
     }
-    if (this.nis) {
-      this.nis.stop();
-    }
   }
 
   getSession(id) {

--- a/node_rtmp_server.js
+++ b/node_rtmp_server.js
@@ -40,6 +40,7 @@ class NodeRtmpServer {
     this.tcpServer.close();
     context.sessions.forEach((session, id) => {
       if (session instanceof NodeRtmpSession) {
+        session.stop();
         session.socket.destroy();
         context.sessions.delete(id);
       }

--- a/node_rtmp_server.js
+++ b/node_rtmp_server.js
@@ -39,11 +39,8 @@ class NodeRtmpServer {
   stop() {
     this.tcpServer.close();
     context.sessions.forEach((session, id) => {
-      if (session instanceof NodeRtmpSession) {
+      if (session instanceof NodeRtmpSession)
         session.stop();
-        session.socket.destroy();
-        context.sessions.delete(id);
-      }
     });
   }
 }


### PR DESCRIPTION
- adds a call to `stop()` rtmp session to avoid undefined errors
- removes lingering `nis` lint in node_media_server.js