### PR TITLE
Allows Devs To Use An Existing Express Server

### DIFF
--- a/node_http_server.js
+++ b/node_http_server.js
@@ -81,6 +81,7 @@ class NodeHttpServer {
     if (this.config.https) {
       if (this.config.https.server) {
         this.httpsServer = this.config.https.server;
+        this.httpsServer.on('request', app);
         this.hasUserdefinedSecureServer = true;
       }
       else {

--- a/node_http_server.js
+++ b/node_http_server.js
@@ -67,7 +67,7 @@ class NodeHttpServer {
 
     if (this.config.http.server) {
       this.httpServer = this.config.http.server;
-      if (!this.config.http.express)
+      if (!this.config.express)
         this.httpServer.on('request', app);
       this.hasUserdefinedServer = true;
     }
@@ -81,7 +81,8 @@ class NodeHttpServer {
     if (this.config.https) {
       if (this.config.https.server) {
         this.httpsServer = this.config.https.server;
-        this.httpsServer.on('request', app);
+        if (!this.config.express)
+          this.httpsServer.on('request', app);
         this.hasUserdefinedSecureServer = true;
       }
       else {

--- a/node_http_server.js
+++ b/node_http_server.js
@@ -32,7 +32,7 @@ class NodeHttpServer {
     this.hasUserdefinedSecureServer = false;
 
     let app;
-    if (this.config.http.express)
+    if (this.config.express)
       app = this.config.http.express;
     else
       app = Express();

--- a/node_http_server.js
+++ b/node_http_server.js
@@ -101,15 +101,15 @@ class NodeHttpServer {
       this.httpServer.listen(this.port, () => {
         Logger.log(`Node Media Http Server started on port: ${this.port}`);
       });
+
+      this.httpServer.on('error', (e) => {
+        Logger.error(`Node Media Http Server ${e}`);
+      });
+
+      this.httpServer.on('close', () => {
+        Logger.log('Node Media Http Server Close.');
+      });
     }
-
-    this.httpServer.on('error', (e) => {
-      Logger.error(`Node Media Http Server ${e}`);
-    });
-
-    this.httpServer.on('close', () => {
-      Logger.log('Node Media Http Server Close.');
-    });
 
     let wsconfig = { server: this.httpServer };
     if (this.config.http.wsroute)
@@ -133,15 +133,15 @@ class NodeHttpServer {
         this.httpsServer.listen(this.sport, () => {
           Logger.log(`Node Media Https Server started on port: ${this.sport}`);
         });
+
+        this.httpsServer.on('error', (e) => {
+          Logger.error(`Node Media Https Server ${e}`);
+        });
+
+        this.httpsServer.on('close', () => {
+          Logger.log('Node Media Https Server Close.');
+        });
       }
-
-      this.httpsServer.on('error', (e) => {
-        Logger.error(`Node Media Https Server ${e}`);
-      });
-
-      this.httpsServer.on('close', () => {
-        Logger.log('Node Media Https Server Close.');
-      });
 
       let wssconfig = { server: this.httpsServer };
       if (this.config.https.wsroute)


### PR DESCRIPTION
This allows developers to combine an existing express server with node-media-server's http server.

The configuration would be as follows:
```
let app = Express()
// -- custom express server stuff --
let server = HTTP.createServer(app)
let secure = HTTPS.createServer(options, app)
// -- http server management in other libraries like express-ws --
let route = '/route-to-websockets'

let config = {
    express: app,
    http: {
        server: server,
        wsroute: route
    },
    https: {
        server: secure,
        wsroute: route
    }
}
```

- If the `express` option is not specified in the config, the library uses default behavior.
- HTTPX servers can also optionally be specified in the config. Default behavior takes place if not present.
- `wsroute` allows a developer to specify a custom websocket path to listen on. For example, "http://localhost/path/to/websocket". If `wsroute` is not specified, websockets listen on the default root path ie default library behavior.
