### PR TITLE
fix: add const before LOG_TYPES assingment

### DIFF
--- a/node_core_logger.js
+++ b/node_core_logger.js
@@ -1,6 +1,6 @@
 const chalk = require('chalk');
 
-LOG_TYPES = {
+const LOG_TYPES = {
   NONE: 0,
   ERROR: 1,
   NORMAL: 2,


### PR DESCRIPTION
assigning variable before declaration throws in strict mode

Closes #242