### PR TITLE
HLS/Dash: Creating empty index file after transmuxing end

### DIFF
--- a/app.js
+++ b/app.js
@@ -74,4 +74,3 @@ nms.on('postPlay', (id, StreamPath, args) => {
 nms.on('donePlay', (id, StreamPath, args) => {
   console.log('[NodeEvent on donePlay]', `id=${id} StreamPath=${StreamPath} args=${JSON.stringify(args)}`);
 });
-

--- a/node_trans_session.js
+++ b/node_trans_session.js
@@ -78,22 +78,27 @@ class NodeTransSession extends EventEmitter {
     this.ffmpeg_exec.on('close', (code) => {
       Logger.log('[Transmuxing end] ' + this.conf.streamPath);
       this.emit('end');
-      fs.readdirSync(ouPath, function (err, files) {
+      fs.readdir(ouPath, function (err, files) {
         if (!err) {
           files.forEach((filename) => {
+			let filepath = ouPath + '/' + filename
+
             if (filename.endsWith('.ts')
-              || filename.endsWith('.m3u8')
-              || filename.endsWith('.mpd')
               || filename.endsWith('.m4s')
               || filename.endsWith('.tmp')) {
-              fs.unlinkSync(ouPath + '/' + filename);
-            }
+              fs.unlinkSync(filepath);
+			}
+
+			if (filename.endsWith('.m3u8')) {
+			  fs.writeFileSync(filepath, '#EXTM3U\n');
+			}
+
+			if (filename.endsWith('.mpd')) {
+			  fs.writeFileSync(filepath, '<?xml version="1.0">\n<MPD></MPD>\n');
+			}
           });
         }
-      });
-      if (this.conf.hls) {
-        fs.writeFileSync(ouPath + '/' + this.hlsFileName, '#EXTM3U\n');
-      }
+	  });
     });
   }
 

--- a/node_trans_session.js
+++ b/node_trans_session.js
@@ -81,24 +81,24 @@ class NodeTransSession extends EventEmitter {
       fs.readdir(ouPath, function (err, files) {
         if (!err) {
           files.forEach((filename) => {
-			let filepath = ouPath + '/' + filename
+            let filepath = ouPath + '/' + filename
 
             if (filename.endsWith('.ts')
               || filename.endsWith('.m4s')
               || filename.endsWith('.tmp')) {
               fs.unlinkSync(filepath);
-			}
+            }
 
-			if (filename.endsWith('.m3u8')) {
-			  fs.writeFileSync(filepath, '#EXTM3U\n');
-			}
+            if (filename.endsWith('.m3u8')) {
+              fs.writeFileSync(filepath, '#EXTM3U\n');
+            }
 
-			if (filename.endsWith('.mpd')) {
-			  fs.writeFileSync(filepath, '<?xml version="1.0">\n<MPD></MPD>\n');
-			}
+            if (filename.endsWith('.mpd')) {
+              fs.writeFileSync(filepath, '<?xml version="1.0">\n<MPD></MPD>\n');
+            }
           });
         }
-	  });
+    });
     });
   }
 

--- a/node_trans_session.js
+++ b/node_trans_session.js
@@ -42,10 +42,10 @@ class NodeTransSession extends EventEmitter {
     }
     if (this.conf.hls) {
       this.conf.hlsFlags = this.conf.hlsFlags ? this.conf.hlsFlags : '';
-      let hlsFileName = 'index.m3u8';
-      let mapHls = `${this.conf.hlsFlags}${ouPath}/${hlsFileName}|`;
+      this.hlsFileName = 'index.m3u8';
+      let mapHls = `${this.conf.hlsFlags}${ouPath}/${this.hlsFileName}|`;
       mapStr += mapHls;
-      Logger.log('[Transmuxing HLS] ' + this.conf.streamPath + ' to ' + ouPath + '/' + hlsFileName);
+      Logger.log('[Transmuxing HLS] ' + this.conf.streamPath + ' to ' + ouPath + '/' + this.hlsFileName);
     }
     if (this.conf.dash) {
       this.conf.dashFlags = this.conf.dashFlags ? this.conf.dashFlags : '';
@@ -78,7 +78,7 @@ class NodeTransSession extends EventEmitter {
     this.ffmpeg_exec.on('close', (code) => {
       Logger.log('[Transmuxing end] ' + this.conf.streamPath);
       this.emit('end');
-      fs.readdir(ouPath, function (err, files) {
+      fs.readdirSync(ouPath, function (err, files) {
         if (!err) {
           files.forEach((filename) => {
             if (filename.endsWith('.ts')
@@ -88,9 +88,12 @@ class NodeTransSession extends EventEmitter {
               || filename.endsWith('.tmp')) {
               fs.unlinkSync(ouPath + '/' + filename);
             }
-          })
+		  });
         }
-      });
+	  });
+	  if (this.conf.hls) {
+		fs.writeFileSync(ouPath + '/' + this.hlsFileName, '#EXTM3U\n');
+	  }
     });
   }
 

--- a/node_trans_session.js
+++ b/node_trans_session.js
@@ -98,7 +98,7 @@ class NodeTransSession extends EventEmitter {
             }
           });
         }
-    });
+      });
     });
   }
 

--- a/node_trans_session.js
+++ b/node_trans_session.js
@@ -88,12 +88,12 @@ class NodeTransSession extends EventEmitter {
               || filename.endsWith('.tmp')) {
               fs.unlinkSync(ouPath + '/' + filename);
             }
-		  });
+          });
         }
-	  });
-	  if (this.conf.hls) {
-		fs.writeFileSync(ouPath + '/' + this.hlsFileName, '#EXTM3U\n');
-	  }
+      });
+      if (this.conf.hls) {
+        fs.writeFileSync(ouPath + '/' + this.hlsFileName, '#EXTM3U\n');
+      }
     });
   }
 


### PR DESCRIPTION
In some players (tested: video.js, JW Player), existence of this file is important for reporting that the stream is offline. Simply deleting a file causes a playback error.