### PR TITLE
Added `streamInUseAppAndName` Property

### DIFF
--- a/node_relay_server.js
+++ b/node_relay_server.js
@@ -106,7 +106,7 @@ class NodeRelayServer {
     });
     this.dynamicSessions.set(id, session);
     session.run();
-    Logger.log('[Relay dynamic push] start', id, conf.inPath, ' to ', conf.ouPath);
+    Logger.log('[Relay dynamic push] start onRelayPush', id, conf.inPath, ' to ', conf.ouPath);
   }
 
   onPrePlay(id, streamPath, args) {
@@ -122,7 +122,11 @@ class NodeRelayServer {
       if (isPull && app === conf.app && !context.publishers.has(streamPath)) {
         let hasApp = conf.edge.match(/rtmp:\/\/([^\/]+)\/([^\/]+)/);
         conf.ffmpeg = this.config.relay.ffmpeg;
-        conf.inPath = hasApp ? `${conf.edge}/${stream}` : `${conf.edge}${streamPath}`;
+        if(conf.hasOwnProperty('streamInUseAppAndName') && conf.streamInUseAppAndName === false){
+			conf.inPath = `${conf.edge}`;
+		}else{
+			conf.inPath = hasApp ? `${conf.edge}/${stream}` : `${conf.edge}${streamPath}`;
+		}
         conf.ouPath = `rtmp://127.0.0.1:${this.config.rtmp.port}${streamPath}`;
         let session = new NodeRelaySession(conf);
         session.id = id;
@@ -131,7 +135,7 @@ class NodeRelayServer {
         });
         this.dynamicSessions.set(id, session);
         session.run();
-        Logger.log('[Relay dynamic pull] start', id, conf.inPath, ' to ', conf.ouPath);
+        Logger.log('[Relay dynamic pull] start onPrePlay', id, conf.inPath, ' to ', conf.ouPath);
       }
     }
   }


### PR DESCRIPTION
Added `streamInUseAppAndName` Property to Prevent Appending App and Name to the inStream URL for a relay pull task entry.  This is needed as some cameras do not allow appending anything to the rtsp:// URL