### PR TITLE
Option for en/disabling the API in the config

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,7 +12,8 @@ const config = {
     port: 8000,
     mediaroot: './media',
     webroot: './www',
-    allow_origin: '*'
+    allow_origin: '*',
+    api: true
   },
   https: {
     port: 8443,

--- a/node_http_server.js
+++ b/node_http_server.js
@@ -52,12 +52,14 @@ class NodeHttpServer {
       });
     }
 
-    if (this.config.auth && this.config.auth.api) {
-      app.use(['/api/*', '/static/*', '/admin/*'], basicAuth(this.config.auth.api_user, this.config.auth.api_pass));
+    if (this.config.http.api !== false) {
+      if (this.config.auth && this.config.auth.api) {
+        app.use(['/api/*', '/static/*', '/admin/*'], basicAuth(this.config.auth.api_user, this.config.auth.api_pass));
+      }
+      app.use('/api/streams', streamsRoute(context));
+      app.use('/api/server', serverRoute(context));
+      app.use('/api/relay', relayRoute(context));
     }
-    app.use('/api/streams', streamsRoute(context));
-    app.use('/api/server', serverRoute(context));
-    app.use('/api/relay', relayRoute(context));
 
     app.use(Express.static(path.join(__dirname + '/public')));
     app.use(Express.static(this.mediaroot));
@@ -71,7 +73,7 @@ class NodeHttpServer {
 
     /**
      * ~ openssl genrsa -out privatekey.pem 1024
-     * ~ openssl req -new -key privatekey.pem -out certrequest.csr 
+     * ~ openssl req -new -key privatekey.pem -out certrequest.csr
      * ~ openssl x509 -req -in certrequest.csr -signkey privatekey.pem -out certificate.pem
      */
     if (this.config.https) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -245,9 +245,9 @@
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://nexus.twasi.net/repository/npm-all/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "media-typer": {
       "version": "0.3.0",


### PR DESCRIPTION
I have a use case where I need the web server to deliver the stream as flv, but do not need the API at all. The streams should not be able to be requested anonymously, and since I don't need the API, it would be safer to disable the API completely rather than secure it with a password.

The API is enabled by default (you don't need to specify it in the config) and can be deactivated by setting config.http.api to false.