### PR TITLE
Add a missing dot to indicate the current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ docker run --name nms -d -p 1935:1935 -p 8000:8000 illuspas/node-media-server
 ```bash
 mkdir nms
 cd nms
-git clone https://github.com/illuspas/Node-Media-Server
+git clone https://github.com/illuspas/Node-Media-Server .
 npm i
 node app.js
 ```


### PR DESCRIPTION
Expected behavior: The repository is cloned into the current directory.
Actual behavior: The repository is cloned into a new directory called Node-Media-Server.

This commit fixes that problem.