### PR TITLE
Moves bodyParser config before defined routes

### DIFF
--- a/api/controllers/relay.js
+++ b/api/controllers/relay.js
@@ -3,6 +3,35 @@
 //  illuspas[a]gmail.com
 //  Copyright (c) 2019 Nodemedia. All rights reserved.
 //
+const _ = require('lodash');
+
+function getStreams(req, res, next) {
+  let stats = {};
+
+  this.sessions.forEach(function (session, id) {
+    if (session.constructor.name !== 'NodeRelaySession') {
+      return;
+    }
+
+    let {app, name} = session.conf;
+
+    if (!_.get(stats, [app, name])) {
+      _.set(stats, [app, name], {
+        relays: []
+      });
+    }
+
+    _.set(stats, [app, name, 'relays'], {
+      app: app,
+      name: name,
+      url: session.conf.ouPath,
+      mode: session.conf.mode,
+      id: session.id,
+    });
+  });
+
+  res.json(stats);
+}
 
 function pullStream(req, res, next) {
   let url = req.body.url;
@@ -29,6 +58,7 @@ function pushStream(req, res, next) {
 }
 
 module.exports = {
+  getStreams,
   pullStream,
   pushStream
 };

--- a/api/routes/relay.js
+++ b/api/routes/relay.js
@@ -3,6 +3,7 @@ const relayController = require('../controllers/relay');
 
 module.exports = (context) => {
   let router = express.Router();
+  router.get('/', relayController.getStreams.bind(context));
   router.post('/pull', relayController.pullStream.bind(context));
   router.post('/push', relayController.pushStream.bind(context));
   return router;

--- a/node_http_server.js
+++ b/node_http_server.js
@@ -32,6 +32,8 @@ class NodeHttpServer {
 
     let app = Express();
 
+    app.use(bodyParser.urlencoded({ extended: true }));
+
     app.all('*', (req, res, next) => {
       res.header("Access-Control-Allow-Origin", this.config.http.allow_origin);
       res.header("Access-Control-Allow-Headers", "Content-Type,Content-Length, Authorization, Accept,X-Requested-With");
@@ -66,8 +68,6 @@ class NodeHttpServer {
     if (config.http.webroot) {
       app.use(Express.static(config.http.webroot));
     }
-
-    app.use(bodyParser.urlencoded({ extended: true }));
 
     this.httpServer = Http.createServer(app);
 

--- a/node_relay_server.js
+++ b/node_relay_server.js
@@ -62,12 +62,13 @@ class NodeRelayServer {
         conf.inPath = conf.edge;
         conf.ouPath = `rtmp://127.0.0.1:${this.config.rtmp.port}/${conf.app}/${conf.name}`;
         let session = new NodeRelaySession(conf);
-        session.id = i;
+        const id = session.id;
+        context.sessions.set(id, session);
         session.streamPath = `/${conf.app}/${conf.name}`;
         session.on('end', (id) => {
           this.staticSessions.delete(id);
         });
-        this.staticSessions.set(i, session);
+        this.staticSessions.set(id, session);
         session.run();
         Logger.log('[Relay static pull] start', i, conf.inPath, ' to ', conf.ouPath);
       }
@@ -77,12 +78,14 @@ class NodeRelayServer {
   //从远端拉推到本地
   onRelayPull(url, app, name) {
     let conf = {};
+    conf.app = app;
+    conf.name = name;
     conf.ffmpeg = this.config.relay.ffmpeg;
     conf.inPath = url;
     conf.ouPath = `rtmp://127.0.0.1:${this.config.rtmp.port}/${app}/${name}`;
-    let id = NodeCoreUtils.generateNewSessionID();
     let session = new NodeRelaySession(conf);
-    session.id = id;
+    const id = session.id;
+    context.sessions.set(id, session);
     session.on('end', (id) => {
       this.dynamicSessions.delete(id);
     });
@@ -95,12 +98,14 @@ class NodeRelayServer {
   //从本地拉推到远端
   onRelayPush(url, app, name) {
     let conf = {};
+    conf.app = app;
+    conf.name = name;
     conf.ffmpeg = this.config.relay.ffmpeg;
     conf.inPath = `rtmp://127.0.0.1:${this.config.rtmp.port}/${app}/${name}`;
     conf.ouPath = url;
-    let id = NodeCoreUtils.generateNewSessionID();
     let session = new NodeRelaySession(conf);
-    session.id = id;
+    const id = session.id;
+    context.sessions.set(id, session);
     session.on('end', (id) => {
       this.dynamicSessions.delete(id);
     });
@@ -161,6 +166,7 @@ class NodeRelayServer {
         conf.ouPath = conf.appendName === false ? conf.edge : (hasApp ? `${conf.edge}/${stream}` : `${conf.edge}${streamPath}`);
         let session = new NodeRelaySession(conf);
         session.id = id;
+    let id = NodeCoreUtils.generateNewSessionID();
         session.on('end', (id) => {
           this.dynamicSessions.delete(id);
         });

--- a/node_relay_server.js
+++ b/node_relay_server.js
@@ -166,7 +166,6 @@ class NodeRelayServer {
         conf.ouPath = conf.appendName === false ? conf.edge : (hasApp ? `${conf.edge}/${stream}` : `${conf.edge}${streamPath}`);
         let session = new NodeRelaySession(conf);
         session.id = id;
-    let id = NodeCoreUtils.generateNewSessionID();
         session.on('end', (id) => {
           this.dynamicSessions.delete(id);
         });

--- a/node_relay_session.js
+++ b/node_relay_session.js
@@ -4,6 +4,7 @@
 //  Copyright (c) 2018 Nodemedia. All rights reserved.
 //
 const Logger = require('./node_core_logger');
+const NodeCoreUtils = require("./node_core_utils");
 
 const EventEmitter = require('events');
 const { spawn } = require('child_process');
@@ -14,6 +15,7 @@ class NodeRelaySession extends EventEmitter {
   constructor(conf) {
     super();
     this.conf = conf;
+    this.id = NodeCoreUtils.generateNewSessionID();
   }
 
   run() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-media-server",
-  "version": "2.1.7",
+  "version": "2.1.6",
   "description": "A Node.js implementation of RTMP Server",
   "main": "node_media_server.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-media-server",
-  "version": "2.1.6",
+  "version": "2.1.7",
   "description": "A Node.js implementation of RTMP Server",
   "main": "node_media_server.js",
   "scripts": {


### PR DESCRIPTION
Fixes an issue where apis were throwing NPE on req.body because routes were defined before the body parser has been configured.