### PR TITLE
Fixes memory leak issue with static pulls

### DIFF
--- a/node_relay_server.js
+++ b/node_relay_server.js
@@ -62,8 +62,7 @@ class NodeRelayServer {
         conf.inPath = conf.edge;
         conf.ouPath = `rtmp://127.0.0.1:${this.config.rtmp.port}/${conf.app}/${conf.name}`;
         let session = new NodeRelaySession(conf);
-        const id = session.id;
-        context.sessions.set(id, session);
+        session.id = i;
         session.streamPath = `/${conf.app}/${conf.name}`;
         session.on('end', (id) => {
           this.staticSessions.delete(id);

--- a/node_relay_server.js
+++ b/node_relay_server.js
@@ -68,9 +68,9 @@ class NodeRelayServer {
         session.on('end', (id) => {
           this.staticSessions.delete(id);
         });
-        this.staticSessions.set(id, session);
+        this.staticSessions.set(i, session);
         session.run();
-        Logger.log('[Relay static pull] start', i, conf.inPath, ' to ', conf.ouPath);
+        Logger.log('[Relay static pull] start', id, conf.inPath, ' to ', conf.ouPath);
       }
     }
   }


### PR DESCRIPTION
In commit bb99b70dc4588dc5f21c3974c91a6d5800a8d7e9, I inadvertently changed the id used in the staticSessions map in the relay server which means that it will create static sessions every second.