### PR TITLE
Fixes memory leak issue with static pulls

### DIFF
--- a/api/controllers/server.js
+++ b/api/controllers/server.js
@@ -57,6 +57,7 @@ function getSessionsInfo(sessions) {
   };
 
   for (let session of sessions.values()) {
+    if (session.TAG === 'relay') continue;
     let socket = session.TAG === 'rtmp' ? session.socket : session.req.socket;
     info.inbytes += socket.bytesRead;
     info.outbytes += socket.bytesWritten;

--- a/node_relay_server.js
+++ b/node_relay_server.js
@@ -62,8 +62,7 @@ class NodeRelayServer {
         conf.inPath = conf.edge;
         conf.ouPath = `rtmp://127.0.0.1:${this.config.rtmp.port}/${conf.app}/${conf.name}`;
         let session = new NodeRelaySession(conf);
-        const id = session.id;
-        context.sessions.set(id, session);
+        session.id = i;
         session.streamPath = `/${conf.app}/${conf.name}`;
         session.on('end', (id) => {
           this.staticSessions.delete(id);

--- a/node_relay_server.js
+++ b/node_relay_server.js
@@ -68,9 +68,9 @@ class NodeRelayServer {
         session.on('end', (id) => {
           this.staticSessions.delete(id);
         });
-        this.staticSessions.set(id, session);
+        this.staticSessions.set(i, session);
         session.run();
-        Logger.log('[Relay static pull] start', i, conf.inPath, ' to ', conf.ouPath);
+        Logger.log('[Relay static pull] start', id, conf.inPath, ' to ', conf.ouPath);
       }
     }
   }

--- a/node_relay_session.js
+++ b/node_relay_session.js
@@ -16,6 +16,7 @@ class NodeRelaySession extends EventEmitter {
     super();
     this.conf = conf;
     this.id = NodeCoreUtils.generateNewSessionID();
+    this.TAG = 'relay';
   }
 
   run() {


### PR DESCRIPTION
In commit bb99b70, I inadvertently changed the id used in the staticSessions map in the relay server which means that it will create static sessions every second. Also, this fixes the server API which broke trying to pull stats for NodeRelaySessions.