### PR TITLE
Reject Already stream RTMP

### DIFF
--- a/node_rtmp_session.js
+++ b/node_rtmp_session.js
@@ -1022,6 +1022,7 @@ class NodeRtmpSession {
     }
 
     if (context.publishers.has(this.publishStreamPath)) {
+      this.reject();
       Logger.log(`[rtmp publish] Already has a stream. id=${this.id} streamPath=${this.publishStreamPath} streamId=${this.publishStreamId}`);
       this.sendStatusMessage(this.publishStreamId, "error", "NetStream.Publish.BadName", "Stream already publishing");
     } else if (this.isPublishing) {


### PR DESCRIPTION
Reject Already streamPath to prevent OBS freeze

```
 if (context.publishers.has(this.publishStreamPath)) {
      this.reject(); //this!
      Logger.log(`[rtmp publish] Already has a stream. id=${this.id} streamPath=${this.publishStreamPath} streamId=${this.publishStreamId}`);
      this.sendStatusMessage(this.publishStreamId, "error", "NetStream.Publish.BadName", "Stream already publishing");
    }

```