### PR TITLE
Modify URLs given to download ffmpeg when it's not present

### DIFF
--- a/node_core_utils.js
+++ b/node_core_utils.js
@@ -77,7 +77,7 @@ function getFFmpegUrl() {
       url = 'https://ffmpeg.zeranoe.com/builds/win64/static/ffmpeg-latest-win64-static.zip | https://ffmpeg.zeranoe.com/builds/win32/static/ffmpeg-latest-win32-static.zip';
       break;
     case 'linux':
-      url = 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz | https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-32bit-static.tar.xz';
+      url = 'https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz | https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-i686-static.tar.xz';
       break;
     default:
       url = 'http://ffmpeg.org/download.html';


### PR DESCRIPTION
In the latest release there there is a notice given to me when I attempt to start up using ffmpeg 3 provided by APT repositories.  Provided URL for download returns 404.  This PR provides the correct URLs

```
alex@alex-ubuntu:~/nms$ node app.js
8/10/2020 06:35:23 60049 [INFO] Node Media Server v2.2.2
8/10/2020 06:35:23 60049 [INFO] Node Media Rtmp Server started on port: 1935
8/10/2020 06:35:23 60049 [INFO] Node Media Http Server started on port: 8000
8/10/2020 06:35:23 60049 [INFO] Node Media WebSocket Server started on port: 8000
8/10/2020 06:35:23 60049 [ERROR] Node Media Trans Server startup failed. ffmpeg requires version 4.0.0 above
8/10/2020 06:35:23 60049 [ERROR] Download the latest ffmpeg static program: https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz | https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-32bit-static.tar.xz

alex@alex-ubuntu:~/nms$ wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz
--2020-08-10 06:35:35--  https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz
Resolving johnvansickle.com (johnvansickle.com)... 162.222.226.121
Connecting to johnvansickle.com (johnvansickle.com)|162.222.226.121|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2020-08-10 06:35:35 ERROR 404: Not Found.
```

The correct url changes "64bit" to "amd64" and "32bit" to "i686"
```

alex@alex-ubuntu:~/nms$ wget https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
--2020-08-10 06:41:17--  https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-amd64-static.tar.xz
Resolving johnvansickle.com (johnvansickle.com)... 162.222.226.121
Connecting to johnvansickle.com (johnvansickle.com)|162.222.226.121|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 38599740 (37M) [application/x-xz]
Saving to: ‘ffmpeg-release-amd64-static.tar.xz’

ffmpeg-release-amd64-static.t 100%[==============================================>]  36.81M  22.6MB/s    in 1.6s

2020-08-10 06:41:18 (22.6 MB/s) - ‘ffmpeg-release-amd64-static.tar.xz’ saved [38599740/38599740]
```