### PR TITLE
Fixing session cannot be create

### DIFF
--- a/node_rtmp_session.js
+++ b/node_rtmp_session.js
@@ -997,8 +997,11 @@ class NodeRtmpSession {
 
     if (context.publishers.has(this.publishStreamPath)) {
       Logger.log(`[rtmp publish] Already has a stream. id=${this.id} streamPath=${this.publishStreamPath} streamId=${this.publishStreamId}`);
-      this.sendStatusMessage(this.publishStreamId, 'error', 'NetStream.Publish.BadName', 'Stream already publishing');
-    } else if (this.isPublishing) {
+      Logger.log(`[rtmp deleting] Trying delete stream. id=${this.id} streamPath=${this.publishStreamPath} streamId=${this.publishStreamId}`);
+      context.publishers.delete(this.publishStreamPath);
+      //this.sendStatusMessage(this.publishStreamId, "error", "NetStream.Publish.BadName", "Stream already publishing");
+    }
+    if (this.isPublishing) {
       Logger.log(`[rtmp publish] NetConnection is publishing. id=${this.id} streamPath=${this.publishStreamPath} streamId=${this.publishStreamId}`);
       this.sendStatusMessage(this.publishStreamId, 'error', 'NetStream.Publish.BadConnection', 'Connection already publishing');
     } else {


### PR DESCRIPTION
When killing a connection with the rtmp server or when turning off the computer while doing a transmission, if you try to transmit again after turning on the computer or going back to the internet, the server does not accept because it informs you that a connection already exists.
This pull request fixed that.
![code-review](https://user-images.githubusercontent.com/61070951/113409962-b7000800-9388-11eb-9493-d18e5eb356f5.gif)
