### PR TITLE
Fix bitrate to be more accurate

### DIFF
--- a/api/controllers/streams.js
+++ b/api/controllers/streams.js
@@ -136,13 +136,7 @@ function getStream(req, res, next) {
     ? Math.ceil((Date.now() - publisherSession.startTimestamp) / 1000)
     : 0;
   streamStats.bitrate =
-    streamStats.duration > 0
-      ? Math.ceil(
-          (_.get(publisherSession, ["socket", "bytesRead"], 0) * 8) /
-            streamStats.duration /
-            1024
-        )
-      : 0;
+    streamStats.duration > 0 ? publisherSession.bitrate : 0;
   streamStats.startTime = streamStats.isLive
     ? publisherSession.connectTime
     : null;


### PR DESCRIPTION
The bitrate on the stats page is not accurate it takes the average from the start of the stream #262, #429.
I introduced a new field `bitrate` that gets updated with the average over the past second.
This code is inspired by SLS.