### PR TITLE
Allow skipping new version check

### DIFF
--- a/src/node_media_server.js
+++ b/src/node_media_server.js
@@ -66,25 +66,26 @@ class NodeMediaServer {
     process.on('SIGINT', function() {
       process.exit();
     });
-
-    Https.get('https://registry.npmjs.org/node-media-server', function (res) {
-      let size = 0;
-      let chunks = [];
-      res.on('data', function (chunk) {
-        size += chunk.length;
-        chunks.push(chunk);
+    if (!config.skipUpdateCheck) {
+      Https.get('https://registry.npmjs.org/node-media-server', function (res) {
+        let size = 0;
+        let chunks = [];
+        res.on('data', function (chunk) {
+          size += chunk.length;
+          chunks.push(chunk);
+        });
+        res.on('end', function () {
+          let data = Buffer.concat(chunks, size);
+          let jsonData = JSON.parse(data.toString());
+          let latestVersion = jsonData['dist-tags']['latest'];
+          let latestVersionNum = latestVersion.split('.')[0] << 16 | latestVersion.split('.')[1] << 8 | latestVersion.split('.')[2] & 0xff;
+          let thisVersionNum = Package.version.split('.')[0] << 16 | Package.version.split('.')[1] << 8 | Package.version.split('.')[2] & 0xff;
+          if (thisVersionNum < latestVersionNum) {
+            Logger.log(`There is a new version ${latestVersion} that can be updated`);
+          }
+        });
       });
-      res.on('end', function () {
-        let data = Buffer.concat(chunks, size);
-        let jsonData = JSON.parse(data.toString());
-        let latestVersion = jsonData['dist-tags']['latest'];
-        let latestVersionNum = latestVersion.split('.')[0] << 16 | latestVersion.split('.')[1] << 8 | latestVersion.split('.')[2] & 0xff;
-        let thisVersionNum = Package.version.split('.')[0] << 16 | Package.version.split('.')[1] << 8 | Package.version.split('.')[2] & 0xff;
-        if (thisVersionNum < latestVersionNum) {
-          Logger.log(`There is a new version ${latestVersion} that can be updated`);
-        }
-      });
-    });
+    }
   }
 
   on(eventName, listener) {


### PR DESCRIPTION
If the response returned by registry.npmjs.org is not json, the startup will fail (happened me twice).
With this new flag, the original behavior is preseved, but allows skipping this new version check if the developer wants to.

Thanks!