### PR TITLE
Fixed multiple dynamic relays

### DIFF
--- a/src/node_relay_server.js
+++ b/src/node_relay_server.js
@@ -15,6 +15,7 @@ const _ = require('lodash');
 
 class NodeRelayServer {
   constructor(config) {
+    console.log(config)
     this.config = config;
     this.staticCycle = null;
     this.staticSessions = new Map();
@@ -120,16 +121,16 @@ class NodeRelayServer {
     }
     let regRes = /\/(.*)\/(.*)/gi.exec(streamPath);
     let [app, stream] = _.slice(regRes, 1);
-    let i = this.config.relay.tasks.length;
-    while (i--) {
-      let conf = this.config.relay.tasks[i];
+
+    let conf = this.config.relay.tasks.find((config) => config.name === stream);
+    if (conf) {
       let isPull = conf.mode === 'pull';
-      if (isPull && app === conf.app && !context.publishers.has(streamPath)) {
+      if (isPull && app === conf.app && !context.publishers.has(streamPath) && conf) {
         let hasApp = conf.edge.match(/rtmp:\/\/([^\/]+)\/([^\/]+)/);
         conf.ffmpeg = this.config.relay.ffmpeg;
-        conf.inPath = hasApp ? `${conf.edge}/${stream}` : `${conf.edge}${streamPath}`;
+        conf.inPath = hasApp ? `${conf.edge}/${stream}` : `${conf.edge}`;
         conf.ouPath = `rtmp://127.0.0.1:${this.config.rtmp.port}${streamPath}`;
-        if(Object.keys(args).length > 0) {
+        if (Object.keys(args).length > 0) {
           conf.inPath += '?';
           conf.inPath += querystring.encode(args);
         }
@@ -168,7 +169,7 @@ class NodeRelayServer {
         conf.ffmpeg = this.config.relay.ffmpeg;
         conf.inPath = `rtmp://127.0.0.1:${this.config.rtmp.port}${streamPath}`;
         conf.ouPath = conf.appendName === false ? conf.edge : (hasApp ? `${conf.edge}/${stream}` : `${conf.edge}${streamPath}`);
-        if(Object.keys(args).length > 0) {
+        if (Object.keys(args).length > 0) {
           conf.ouPath += '?';
           conf.ouPath += querystring.encode(args);
         }

--- a/src/node_relay_server.js
+++ b/src/node_relay_server.js
@@ -4,60 +4,204 @@
 //  Copyright (c) 2018 Nodemedia. All rights reserved.
 //
 const Logger = require('./node_core_logger');
+
 const NodeCoreUtils = require('./node_core_utils');
+const NodeRelaySession = require('./node_relay_session');
+const context = require('./node_core_ctx');
+const { getFFmpegVersion, getFFmpegUrl } = require('./node_core_utils');
+const fs = require('fs');
+const querystring = require('querystring');
+const _ = require('lodash');
 
-const EventEmitter = require('events');
-const { spawn } = require('child_process');
-
-const RTSP_TRANSPORT = ['udp', 'tcp', 'udp_multicast', 'http'];
-
-class NodeRelaySession extends EventEmitter {
-  constructor(conf) {
-    super();
-    this.conf = conf;
-    this.id = NodeCoreUtils.generateNewSessionID();
-    this.TAG = 'relay';
+class NodeRelayServer {
+  constructor(config) {
+    this.config = config;
+    this.staticCycle = null;
+    this.staticSessions = new Map();
+    this.dynamicSessions = new Map();
   }
 
-  run() {
-    let format = this.conf.ouPath.startsWith('rtsp://') ? 'rtsp' : 'flv';
-    let argv = ['-re', '-i', this.conf.inPath, '-c', 'copy', '-f', format, this.conf.ouPath];
-    if (this.conf.inPath[0] === '/' || this.conf.inPath[1] === ':') {
-      argv.unshift('-1');
-      argv.unshift('-stream_loop');
+  async run() {
+    try {
+      fs.accessSync(this.config.relay.ffmpeg, fs.constants.X_OK);
+    } catch (error) {
+      Logger.error(`Node Media Relay Server startup failed. ffmpeg:${this.config.relay.ffmpeg} cannot be executed.`);
+      return;
     }
 
-    if (this.conf.inPath.startsWith('rtsp://') && this.conf.rtsp_transport) {
-      if (RTSP_TRANSPORT.indexOf(this.conf.rtsp_transport) > -1) {
-        argv.unshift(this.conf.rtsp_transport);
-        argv.unshift('-rtsp_transport');
+    let version = await getFFmpegVersion(this.config.relay.ffmpeg);
+    if (version === '' || parseInt(version.split('.')[0]) < 4) {
+      Logger.error('Node Media Relay Server startup failed. ffmpeg requires version 4.0.0 above');
+      Logger.error('Download the latest ffmpeg static program:', getFFmpegUrl());
+      return;
+    }
+    context.nodeEvent.on('relayPull', this.onRelayPull.bind(this));
+    context.nodeEvent.on('relayPush', this.onRelayPush.bind(this));
+    context.nodeEvent.on('prePlay', this.onPrePlay.bind(this));
+    context.nodeEvent.on('donePlay', this.onDonePlay.bind(this));
+    context.nodeEvent.on('postPublish', this.onPostPublish.bind(this));
+    context.nodeEvent.on('donePublish', this.onDonePublish.bind(this));
+    this.staticCycle = setInterval(this.onStatic.bind(this), 1000);
+    Logger.log('Node Media Relay Server started');
+  }
+
+  onStatic() {
+    if (!this.config.relay.tasks) {
+      return;
+    }
+    let i = this.config.relay.tasks.length;
+    while (i--) {
+      if (this.staticSessions.has(i)) {
+        continue;
+      }
+
+      let conf = this.config.relay.tasks[i];
+      let isStatic = conf.mode === 'static';
+      if (isStatic) {
+        conf.name = conf.name ? conf.name : NodeCoreUtils.genRandomName();
+        conf.ffmpeg = this.config.relay.ffmpeg;
+        conf.inPath = conf.edge;
+        conf.ouPath = `rtmp://127.0.0.1:${this.config.rtmp.port}/${conf.app}/${conf.name}`;
+        let session = new NodeRelaySession(conf);
+        session.id = i;
+        session.streamPath = `/${conf.app}/${conf.name}`;
+        session.on('end', (id) => {
+          this.staticSessions.delete(id);
+        });
+        this.staticSessions.set(i, session);
+        session.run();
+        Logger.log('[relay static pull] start', i, conf.inPath, 'to', conf.ouPath);
       }
     }
-    
-    Logger.log('[relay task] id='+this.id,'cmd=ffmpeg', argv.join(' '));
-
-    this.ffmpeg_exec = spawn(this.conf.ffmpeg, argv);
-    this.ffmpeg_exec.on('error', (e) => {
-      Logger.ffdebug(e);
-    });
-
-    this.ffmpeg_exec.stdout.on('data', (data) => {
-      Logger.ffdebug(`FF输出：${data}`);
-    });
-
-    this.ffmpeg_exec.stderr.on('data', (data) => {
-      Logger.ffdebug(`FF输出：${data}`);
-    });
-
-    this.ffmpeg_exec.on('close', (code) => {
-      Logger.log('[relay end] id='+this.id,'code='+code);
-      this.emit('end', this.id);
-    });
   }
 
-  end() {
-    this.ffmpeg_exec.kill();
+  //从远端拉推到本地
+  onRelayPull(url, app, name) {
+    let conf = {};
+    conf.app = app;
+    conf.name = name;
+    conf.ffmpeg = this.config.relay.ffmpeg;
+    conf.inPath = url;
+    conf.ouPath = `rtmp://127.0.0.1:${this.config.rtmp.port}/${app}/${name}`;
+    let session = new NodeRelaySession(conf);
+    const id = session.id;
+    context.sessions.set(id, session);
+    session.on('end', (id) => {
+      this.dynamicSessions.delete(id);
+    });
+    this.dynamicSessions.set(id, session);
+    session.run();
+    Logger.log('[relay dynamic pull] start id=' + id, conf.inPath, 'to', conf.ouPath);
+    return id;
+  }
+
+  //从本地拉推到远端
+  onRelayPush(url, app, name) {
+    let conf = {};
+    conf.app = app;
+    conf.name = name;
+    conf.ffmpeg = this.config.relay.ffmpeg;
+    conf.inPath = `rtmp://127.0.0.1:${this.config.rtmp.port}/${app}/${name}`;
+    conf.ouPath = url;
+    let session = new NodeRelaySession(conf);
+    const id = session.id;
+    context.sessions.set(id, session);
+    session.on('end', (id) => {
+      this.dynamicSessions.delete(id);
+    });
+    this.dynamicSessions.set(id, session);
+    session.run();
+    Logger.log('[relay dynamic push] start id=' + id, conf.inPath, 'to', conf.ouPath);
+  }
+
+  onPrePlay(id, streamPath, args) {
+    if (!this.config.relay.tasks) {
+      return;
+    }
+    let regRes = /\/(.*)\/(.*)/gi.exec(streamPath);
+    let [app, stream] = _.slice(regRes, 1);
+
+    let conf = this.config.relay.tasks.find((config) => config.name === stream);
+    if (conf) {
+      let isPull = conf.mode === 'pull';
+      if (isPull && app === conf.app && !context.publishers.has(streamPath)) {
+        let hasApp = conf.edge.match(/rtmp:\/\/([^\/]+)\/([^\/]+)/);
+        conf.ffmpeg = this.config.relay.ffmpeg;
+        conf.inPath = hasApp ? `${conf.edge}/${stream}` : `${conf.edge}`;
+        conf.ouPath = `rtmp://127.0.0.1:${this.config.rtmp.port}${streamPath}`;
+        if(Object.keys(args).length > 0) {
+          conf.inPath += '?';
+          conf.inPath += querystring.encode(args);
+        }
+        let session = new NodeRelaySession(conf);
+        session.id = id;
+        session.on('end', (id) => {
+          this.dynamicSessions.delete(id);
+        });
+        this.dynamicSessions.set(id, session);
+        session.run();
+        Logger.log('[relay dynamic pull] start id=' + id, conf.inPath, 'to', conf.ouPath);
+      }
+
+    }
+  }
+
+  onDonePlay(id, streamPath, args) {
+    let session = this.dynamicSessions.get(id);
+    let publisher = context.sessions.get(context.publishers.get(streamPath));
+    if (session && publisher.players.size == 0) {
+      session.end();
+    }
+  }
+
+  onPostPublish(id, streamPath, args) {
+    if (!this.config.relay.tasks) {
+      return;
+    }
+    let regRes = /\/(.*)\/(.*)/gi.exec(streamPath);
+    let [app, stream] = _.slice(regRes, 1);
+    let i = this.config.relay.tasks.length;
+    while (i--) {
+      let conf = this.config.relay.tasks[i];
+      let isPush = conf.mode === 'push';
+      if (isPush && app === conf.app) {
+        let hasApp = conf.edge.match(/rtmp:\/\/([^\/]+)\/([^\/]+)/);
+        conf.ffmpeg = this.config.relay.ffmpeg;
+        conf.inPath = `rtmp://127.0.0.1:${this.config.rtmp.port}${streamPath}`;
+        conf.ouPath = conf.appendName === false ? conf.edge : (hasApp ? `${conf.edge}/${stream}` : `${conf.edge}${streamPath}`);
+        if(Object.keys(args).length > 0) {
+          conf.ouPath += '?';
+          conf.ouPath += querystring.encode(args);
+        }
+        let session = new NodeRelaySession(conf);
+        session.id = id;
+        session.on('end', (id) => {
+          this.dynamicSessions.delete(id);
+        });
+        this.dynamicSessions.set(id, session);
+        session.run();
+        Logger.log('[relay dynamic push] start id=' + id, conf.inPath, 'to', conf.ouPath);
+      }
+    }
+
+  }
+
+  onDonePublish(id, streamPath, args) {
+    let session = this.dynamicSessions.get(id);
+    if (session) {
+      session.end();
+    }
+
+    for (session of this.staticSessions.values()) {
+      if (session.streamPath === streamPath) {
+        session.end();
+      }
+    }
+  }
+
+  stop() {
+    clearInterval(this.staticCycle);
   }
 }
 
-module.exports = NodeRelaySession;
+module.exports = NodeRelayServer;

--- a/src/node_relay_server.js
+++ b/src/node_relay_server.js
@@ -147,7 +147,7 @@ class NodeRelayServer {
   }
 
   onDonePlay(id, streamPath, args) {
-    let session = this.dynamicSessions.get(id);
+    let session = Array.from(this.dynamicSessions, ([name, value]) => value ).find((session)=>{return session.conf.name === streamPath.split('/')[2]});
     let publisher = context.sessions.get(context.publishers.get(streamPath));
     if (session && publisher.players.size == 0) {
       session.end();

--- a/src/node_relay_server.js
+++ b/src/node_relay_server.js
@@ -4,204 +4,60 @@
 //  Copyright (c) 2018 Nodemedia. All rights reserved.
 //
 const Logger = require('./node_core_logger');
-
 const NodeCoreUtils = require('./node_core_utils');
-const NodeRelaySession = require('./node_relay_session');
-const context = require('./node_core_ctx');
-const { getFFmpegVersion, getFFmpegUrl } = require('./node_core_utils');
-const fs = require('fs');
-const querystring = require('querystring');
-const _ = require('lodash');
 
-class NodeRelayServer {
-  constructor(config) {
-    console.log(config)
-    this.config = config;
-    this.staticCycle = null;
-    this.staticSessions = new Map();
-    this.dynamicSessions = new Map();
+const EventEmitter = require('events');
+const { spawn } = require('child_process');
+
+const RTSP_TRANSPORT = ['udp', 'tcp', 'udp_multicast', 'http'];
+
+class NodeRelaySession extends EventEmitter {
+  constructor(conf) {
+    super();
+    this.conf = conf;
+    this.id = NodeCoreUtils.generateNewSessionID();
+    this.TAG = 'relay';
   }
 
-  async run() {
-    try {
-      fs.accessSync(this.config.relay.ffmpeg, fs.constants.X_OK);
-    } catch (error) {
-      Logger.error(`Node Media Relay Server startup failed. ffmpeg:${this.config.relay.ffmpeg} cannot be executed.`);
-      return;
+  run() {
+    let format = this.conf.ouPath.startsWith('rtsp://') ? 'rtsp' : 'flv';
+    let argv = ['-re', '-i', this.conf.inPath, '-c', 'copy', '-f', format, this.conf.ouPath];
+    if (this.conf.inPath[0] === '/' || this.conf.inPath[1] === ':') {
+      argv.unshift('-1');
+      argv.unshift('-stream_loop');
     }
 
-    let version = await getFFmpegVersion(this.config.relay.ffmpeg);
-    if (version === '' || parseInt(version.split('.')[0]) < 4) {
-      Logger.error('Node Media Relay Server startup failed. ffmpeg requires version 4.0.0 above');
-      Logger.error('Download the latest ffmpeg static program:', getFFmpegUrl());
-      return;
-    }
-    context.nodeEvent.on('relayPull', this.onRelayPull.bind(this));
-    context.nodeEvent.on('relayPush', this.onRelayPush.bind(this));
-    context.nodeEvent.on('prePlay', this.onPrePlay.bind(this));
-    context.nodeEvent.on('donePlay', this.onDonePlay.bind(this));
-    context.nodeEvent.on('postPublish', this.onPostPublish.bind(this));
-    context.nodeEvent.on('donePublish', this.onDonePublish.bind(this));
-    this.staticCycle = setInterval(this.onStatic.bind(this), 1000);
-    Logger.log('Node Media Relay Server started');
-  }
-
-  onStatic() {
-    if (!this.config.relay.tasks) {
-      return;
-    }
-    let i = this.config.relay.tasks.length;
-    while (i--) {
-      if (this.staticSessions.has(i)) {
-        continue;
-      }
-
-      let conf = this.config.relay.tasks[i];
-      let isStatic = conf.mode === 'static';
-      if (isStatic) {
-        conf.name = conf.name ? conf.name : NodeCoreUtils.genRandomName();
-        conf.ffmpeg = this.config.relay.ffmpeg;
-        conf.inPath = conf.edge;
-        conf.ouPath = `rtmp://127.0.0.1:${this.config.rtmp.port}/${conf.app}/${conf.name}`;
-        let session = new NodeRelaySession(conf);
-        session.id = i;
-        session.streamPath = `/${conf.app}/${conf.name}`;
-        session.on('end', (id) => {
-          this.staticSessions.delete(id);
-        });
-        this.staticSessions.set(i, session);
-        session.run();
-        Logger.log('[relay static pull] start', i, conf.inPath, 'to', conf.ouPath);
+    if (this.conf.inPath.startsWith('rtsp://') && this.conf.rtsp_transport) {
+      if (RTSP_TRANSPORT.indexOf(this.conf.rtsp_transport) > -1) {
+        argv.unshift(this.conf.rtsp_transport);
+        argv.unshift('-rtsp_transport');
       }
     }
-  }
+    
+    Logger.log('[relay task] id='+this.id,'cmd=ffmpeg', argv.join(' '));
 
-  //从远端拉推到本地
-  onRelayPull(url, app, name) {
-    let conf = {};
-    conf.app = app;
-    conf.name = name;
-    conf.ffmpeg = this.config.relay.ffmpeg;
-    conf.inPath = url;
-    conf.ouPath = `rtmp://127.0.0.1:${this.config.rtmp.port}/${app}/${name}`;
-    let session = new NodeRelaySession(conf);
-    const id = session.id;
-    context.sessions.set(id, session);
-    session.on('end', (id) => {
-      this.dynamicSessions.delete(id);
+    this.ffmpeg_exec = spawn(this.conf.ffmpeg, argv);
+    this.ffmpeg_exec.on('error', (e) => {
+      Logger.ffdebug(e);
     });
-    this.dynamicSessions.set(id, session);
-    session.run();
-    Logger.log('[relay dynamic pull] start id=' + id, conf.inPath, 'to', conf.ouPath);
-    return id;
-  }
 
-  //从本地拉推到远端
-  onRelayPush(url, app, name) {
-    let conf = {};
-    conf.app = app;
-    conf.name = name;
-    conf.ffmpeg = this.config.relay.ffmpeg;
-    conf.inPath = `rtmp://127.0.0.1:${this.config.rtmp.port}/${app}/${name}`;
-    conf.ouPath = url;
-    let session = new NodeRelaySession(conf);
-    const id = session.id;
-    context.sessions.set(id, session);
-    session.on('end', (id) => {
-      this.dynamicSessions.delete(id);
+    this.ffmpeg_exec.stdout.on('data', (data) => {
+      Logger.ffdebug(`FF输出：${data}`);
     });
-    this.dynamicSessions.set(id, session);
-    session.run();
-    Logger.log('[relay dynamic push] start id=' + id, conf.inPath, 'to', conf.ouPath);
+
+    this.ffmpeg_exec.stderr.on('data', (data) => {
+      Logger.ffdebug(`FF输出：${data}`);
+    });
+
+    this.ffmpeg_exec.on('close', (code) => {
+      Logger.log('[relay end] id='+this.id,'code='+code);
+      this.emit('end', this.id);
+    });
   }
 
-  onPrePlay(id, streamPath, args) {
-    if (!this.config.relay.tasks) {
-      return;
-    }
-    let regRes = /\/(.*)\/(.*)/gi.exec(streamPath);
-    let [app, stream] = _.slice(regRes, 1);
-
-    let conf = this.config.relay.tasks.find((config) => config.name === stream);
-    if (conf) {
-      let isPull = conf.mode === 'pull';
-      if (isPull && app === conf.app && !context.publishers.has(streamPath) && conf) {
-        let hasApp = conf.edge.match(/rtmp:\/\/([^\/]+)\/([^\/]+)/);
-        conf.ffmpeg = this.config.relay.ffmpeg;
-        conf.inPath = hasApp ? `${conf.edge}/${stream}` : `${conf.edge}`;
-        conf.ouPath = `rtmp://127.0.0.1:${this.config.rtmp.port}${streamPath}`;
-        if (Object.keys(args).length > 0) {
-          conf.inPath += '?';
-          conf.inPath += querystring.encode(args);
-        }
-        let session = new NodeRelaySession(conf);
-        session.id = id;
-        session.on('end', (id) => {
-          this.dynamicSessions.delete(id);
-        });
-        this.dynamicSessions.set(id, session);
-        session.run();
-        Logger.log('[relay dynamic pull] start id=' + id, conf.inPath, 'to', conf.ouPath);
-      }
-    }
-  }
-
-  onDonePlay(id, streamPath, args) {
-    let session = this.dynamicSessions.get(id);
-    let publisher = context.sessions.get(context.publishers.get(streamPath));
-    if (session && publisher.players.size == 0) {
-      session.end();
-    }
-  }
-
-  onPostPublish(id, streamPath, args) {
-    if (!this.config.relay.tasks) {
-      return;
-    }
-    let regRes = /\/(.*)\/(.*)/gi.exec(streamPath);
-    let [app, stream] = _.slice(regRes, 1);
-    let i = this.config.relay.tasks.length;
-    while (i--) {
-      let conf = this.config.relay.tasks[i];
-      let isPush = conf.mode === 'push';
-      if (isPush && app === conf.app) {
-        let hasApp = conf.edge.match(/rtmp:\/\/([^\/]+)\/([^\/]+)/);
-        conf.ffmpeg = this.config.relay.ffmpeg;
-        conf.inPath = `rtmp://127.0.0.1:${this.config.rtmp.port}${streamPath}`;
-        conf.ouPath = conf.appendName === false ? conf.edge : (hasApp ? `${conf.edge}/${stream}` : `${conf.edge}${streamPath}`);
-        if (Object.keys(args).length > 0) {
-          conf.ouPath += '?';
-          conf.ouPath += querystring.encode(args);
-        }
-        let session = new NodeRelaySession(conf);
-        session.id = id;
-        session.on('end', (id) => {
-          this.dynamicSessions.delete(id);
-        });
-        this.dynamicSessions.set(id, session);
-        session.run();
-        Logger.log('[relay dynamic push] start id=' + id, conf.inPath, 'to', conf.ouPath);
-      }
-    }
-
-  }
-
-  onDonePublish(id, streamPath, args) {
-    let session = this.dynamicSessions.get(id);
-    if (session) {
-      session.end();
-    }
-
-    for (session of this.staticSessions.values()) {
-      if (session.streamPath === streamPath) {
-        session.end();
-      }
-    }
-  }
-
-  stop() {
-    clearInterval(this.staticCycle);
+  end() {
+    this.ffmpeg_exec.kill();
   }
 }
 
-module.exports = NodeRelayServer;
+module.exports = NodeRelaySession;


### PR DESCRIPTION
When trying to run a relay for multiple streams, the process would fail because of two issues:

The config "inPath" was improperly being set with the stream path. The "inPath" should just be the edge server specified in the config.

Also, the onPrePlay event handler was creating a NodeRelaySession for every single task, even when the only a single onPrePlay event was fired. This would cause NMS to always return the video data for the last entry in the task list. I fixed the onPrePlay event handler to only create a NodeRelaySession for the task associated with the onPrePlayEvent.