### PR TITLE
add feature to remux signed rtmp stream

### DIFF
--- a/src/node_fission_session.js
+++ b/src/node_fission_session.js
@@ -15,7 +15,7 @@ class NodeFissionSession extends EventEmitter {
   }
 
   run() {
-    let inPath = 'rtmp://127.0.0.1:' + this.conf.rtmpPort + this.conf.streamPath;
+    let inPath = 'rtmp://127.0.0.1:' + this.conf.rtmpPort + this.conf.streamPath + ((this.conf.args.sign)? `?sign=${this.conf.args.sign}`: '');
     let argv = ['-i', inPath];
     for (let m of this.conf.model) {
       let x264 = ['-c:v', 'libx264', '-preset', 'veryfast', '-tune', 'zerolatency', '-maxrate', m.vb, '-bufsize', m.vb, '-g', parseInt(m.vf) * 2, '-r', m.vf, '-s', m.vs];

--- a/src/node_trans_session.js
+++ b/src/node_trans_session.js
@@ -20,7 +20,7 @@ class NodeTransSession extends EventEmitter {
   run() {
     let vc = this.conf.vc || 'copy';
     let ac = this.conf.ac || 'copy';
-    let inPath = 'rtmp://127.0.0.1:' + this.conf.rtmpPort + this.conf.streamPath;
+    let inPath = 'rtmp://127.0.0.1:' + this.conf.rtmpPort + this.conf.streamPath + ((this.conf.args.sign)? `?sign=${this.conf.args.sign}`: '');
     let ouPath = `${this.conf.mediaroot}/${this.conf.streamApp}/${this.conf.streamName}`;
     let mapStr = '';
 


### PR DESCRIPTION
Bug: if main stream (RTMP) protected by signed key and user validating the sign argument on "prePlay" event then user won't able to remux because remux don't pass config args to trans session
Fix: pass sign argument if available so user able to remux signed rtmp stream