### PR TITLE
Avoid relay with same name overwrite, add get & delete rest api for relay

### DIFF
--- a/src/api/controllers/relay.js
+++ b/src/api/controllers/relay.js
@@ -15,19 +15,19 @@ function getStreams(req, res, next) {
 
     let { app, name } = session.conf;
 
-    if (!_.get(stats, [app, name])) {
-      _.set(stats, [app, name], {
+    if (!_.get(stats, ['app', 'name'])) {
+      _.set(stats, ['app', 'name'], {
         relays: []
       });
     }
 
-    _.set(stats, [app, name, 'relays'], {
+		stats.app.name.relays.push({
       app: app,
       name: name,
       url: session.conf.ouPath,
       mode: session.conf.mode,
       id: session.id,
-    });
+		})
   });
 
   res.json(stats);

--- a/src/api/controllers/relay.js
+++ b/src/api/controllers/relay.js
@@ -21,13 +21,13 @@ function getStreams(req, res, next) {
       });
     }
 
-		stats[app][name]['relays'].push({
+    stats[app][name]['relays'].push({
       app: app,
       name: name,
       url: session.conf.ouPath,
       mode: session.conf.mode,
       id: session.id,
-		});
+    });
   });
 
   res.json(stats);

--- a/src/api/controllers/relay.js
+++ b/src/api/controllers/relay.js
@@ -33,6 +33,31 @@ function getStreams(req, res, next) {
   res.json(stats);
 }
 
+function getStream(req, res, next) {
+  let stat = {};
+  let relayPath = `${req.params.app}/${req.params.name}`;
+
+  this.sessions.forEach(function (session, id) {
+    if (session.constructor.name !== 'NodeRelaySession') {
+      return;
+    }
+
+    let { app, name } = session.conf;
+    if (relayPath === `${app}/${name}`) {
+      stat = {
+        app: app,
+        name: name,
+        url: session.conf.ouPath,
+        mode: session.conf.mode,
+        id: session.id,
+      };
+      return;
+    }
+  });
+
+  res.json(stat);
+}
+
 function pullStream(req, res, next) {
   let url = req.body.url;
   let app = req.body.app;
@@ -57,8 +82,34 @@ function pushStream(req, res, next) {
   }
 }
 
+function delStream(req, res, next) {
+  let relayExists = false;
+  let relayPath = `${req.params.app}/${req.params.name}`;
+
+  this.sessions.forEach(function (session, id) {
+    if (session.constructor.name !== 'NodeRelaySession') {
+      return;
+    }
+
+    let { app, name } = session.conf;
+    if (relayPath === `${app}/${name}`) {
+			session.end();
+      relayExists = true;
+      return;
+    }
+  });
+
+  if (relayExists) {
+    res.sendStatus(200);
+  } else {
+    res.sendStatus(400);
+  }
+}
+
 module.exports = {
   getStreams,
+  getStream,
   pullStream,
-  pushStream
+  pushStream,
+  delStream
 };

--- a/src/api/controllers/relay.js
+++ b/src/api/controllers/relay.js
@@ -21,13 +21,13 @@ function getStreams(req, res, next) {
       });
     }
 
-		stats.app.name.relays.push({
+    stats.app.name.relays.push({
       app: app,
       name: name,
       url: session.conf.ouPath,
       mode: session.conf.mode,
       id: session.id,
-		})
+    })
   });
 
   res.json(stats);

--- a/src/api/controllers/relay.js
+++ b/src/api/controllers/relay.js
@@ -15,19 +15,19 @@ function getStreams(req, res, next) {
 
     let { app, name } = session.conf;
 
-    if (!_.get(stats, ['app', 'name'])) {
-      _.set(stats, ['app', 'name'], {
+    if (!_.get(stats, [app, name])) {
+      _.set(stats, [app, name], {
         relays: []
       });
     }
 
-    stats.app.name.relays.push({
+		stats[app][name]['relays'].push({
       app: app,
       name: name,
       url: session.conf.ouPath,
       mode: session.conf.mode,
       id: session.id,
-    })
+		});
   });
 
   res.json(stats);

--- a/src/api/controllers/relay.js
+++ b/src/api/controllers/relay.js
@@ -17,7 +17,7 @@ function getStreams(req, res, next) {
 
     if (!_.get(stats, [app, name])) {
       _.set(stats, [app, name], {
-        relays: []
+        relays: [],
       });
     }
 
@@ -34,7 +34,7 @@ function getStreams(req, res, next) {
 }
 
 function getStream(req, res, next) {
-  let stat = {};
+  let relay = {};
   let relayPath = `${req.params.app}/${req.params.name}`;
 
   this.sessions.forEach(function (session, id) {
@@ -44,7 +44,7 @@ function getStream(req, res, next) {
 
     let { app, name } = session.conf;
     if (relayPath === `${app}/${name}`) {
-      stat = {
+      relay = {
         app: app,
         name: name,
         url: session.conf.ouPath,
@@ -55,7 +55,7 @@ function getStream(req, res, next) {
     }
   });
 
-  res.json(stat);
+  res.json(relay);
 }
 
 function pullStream(req, res, next) {
@@ -83,6 +83,7 @@ function pushStream(req, res, next) {
 }
 
 function delStream(req, res, next) {
+  let relay = {};
   let relayExists = false;
   let relayPath = `${req.params.app}/${req.params.name}`;
 
@@ -93,14 +94,21 @@ function delStream(req, res, next) {
 
     let { app, name } = session.conf;
     if (relayPath === `${app}/${name}`) {
-			session.end();
+      session.end();
+      relay = {
+        app: app,
+        name: name,
+        url: session.conf.ouPath,
+        mode: session.conf.mode,
+        id: session.id,
+      };
       relayExists = true;
       return;
     }
   });
 
   if (relayExists) {
-    res.sendStatus(200);
+    res.json(relay);
   } else {
     res.sendStatus(400);
   }
@@ -111,5 +119,5 @@ module.exports = {
   getStream,
   pullStream,
   pushStream,
-  delStream
+  delStream,
 };

--- a/src/api/routes/relay.js
+++ b/src/api/routes/relay.js
@@ -4,7 +4,9 @@ const relayController = require('../controllers/relay');
 module.exports = (context) => {
   let router = express.Router();
   router.get('/', relayController.getStreams.bind(context));
+  router.get('/:app/:name', relayController.getStream.bind(context));
   router.post('/pull', relayController.pullStream.bind(context));
   router.post('/push', relayController.pushStream.bind(context));
+  router.delete('/:app/:name', relayController.delStream.bind(context));
   return router;
 };


### PR DESCRIPTION
Deleting relay using api will stop the session but the stats of the relay will remain available. Not really sure how to remove it completely.