### PR TITLE
Dynamic transcoding config from stream arguments  and Prevent deletion after stream end

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ const config = {
         app: 'live',
         hls: true,
         hlsFlags: '[hls_time=2:hls_list_size=3:hls_flags=delete_segments]',
+        hlsKeep: true, // to prevent file delete after end the stream
         dash: true,
         dashFlags: '[f=dash:window_size=3:extra_window_size=5]'
       }

--- a/README_CN.md
+++ b/README_CN.md
@@ -451,6 +451,7 @@ const config = {
         app: 'live',
         hls: true,
         hlsFlags: '[hls_time=2:hls_list_size=3:hls_flags=delete_segments]',
+        hlsKeep: true, // 防止在结束流后删除文件
         dash: true,
         dashFlags: '[f=dash:window_size=3:extra_window_size=5]'
       }

--- a/src/node_trans_session.js
+++ b/src/node_trans_session.js
@@ -65,8 +65,6 @@ class NodeTransSession extends EventEmitter {
     Array.prototype.push.apply(argv, this.conf.acParam);
     Array.prototype.push.apply(argv, ['-f', 'tee', '-map', '0:a?', '-map', '0:v?', mapStr]);
     argv = argv.filter((n) => { return n; }); //去空
-
-    Logger.log(`[Transmuxing Start] args=${JSON.stringify(argv)}`);
     
     this.ffmpeg_exec = spawn(this.conf.ffmpeg, argv);
     this.ffmpeg_exec.on('error', (e) => {

--- a/src/node_trans_session.js
+++ b/src/node_trans_session.js
@@ -18,6 +18,12 @@ class NodeTransSession extends EventEmitter {
   constructor(conf) {
     super();
     this.conf = conf;
+    this.getConfig = (key = null) => {
+      if (!key) return
+      if (typeof this.conf != 'object') return
+      if (this.conf.args && typeof this.conf.args === 'object' && this.conf.args[key]) return this.conf.args[key]
+      return this.conf[key]
+    }
   }
 
   run() {
@@ -44,7 +50,7 @@ class NodeTransSession extends EventEmitter {
       Logger.log('[Transmuxing MP4] ' + this.conf.streamPath + ' to ' + ouPath + '/' + mp4FileName);
     }
     if (this.conf.hls) {
-      this.conf.hlsFlags = this.conf.hlsFlags ? this.conf.hlsFlags : '';
+      this.conf.hlsFlags = this.getConfig('hlsFlags') || '';
       let hlsFileName = 'index.m3u8';
       let mapHls = `${this.conf.hlsFlags}${ouPath}/${hlsFileName}|`;
       mapStr += mapHls;
@@ -93,7 +99,7 @@ class NodeTransSession extends EventEmitter {
 
   // delete hls files
   deleteHlsFiles (ouPath) {
-    if ((!ouPath && !this.conf.hls) || this.conf.hlsKeep) return
+    if ((!ouPath && !this.conf.hls) || this.getConfig('hlsKeep')) return
     fs.readdir(ouPath, function (err, files) {
       if (err) return
       files.filter((filename) => isHlsFile(filename)).forEach((filename) => {

--- a/src/node_trans_session.js
+++ b/src/node_trans_session.js
@@ -62,6 +62,9 @@ class NodeTransSession extends EventEmitter {
     Array.prototype.push.apply(argv, this.conf.acParam);
     Array.prototype.push.apply(argv, ['-f', 'tee', '-map', '0:a?', '-map', '0:v?', mapStr]);
     argv = argv.filter((n) => { return n; }); //去空
+
+    Logger.log(`[Transmuxing start] args=${JSON.stringify(argv)}`);
+    
     this.ffmpeg_exec = spawn(this.conf.ffmpeg, argv);
     this.ffmpeg_exec.on('error', (e) => {
       Logger.ffdebug(e);
@@ -78,19 +81,19 @@ class NodeTransSession extends EventEmitter {
     this.ffmpeg_exec.on('close', (code) => {
       Logger.log('[Transmuxing end] ' + this.conf.streamPath);
       this.emit('end');
-      fs.readdir(ouPath, function (err, files) {
-        if (!err) {
-          files.forEach((filename) => {
-            if (filename.endsWith('.ts')
-              || filename.endsWith('.m3u8')
-              || filename.endsWith('.mpd')
-              || filename.endsWith('.m4s')
-              || filename.endsWith('.tmp')) {
-              fs.unlinkSync(ouPath + '/' + filename);
-            }
-          });
-        }
-      });
+      // fs.readdir(ouPath, function (err, files) {
+      //   if (!err) {
+      //     files.forEach((filename) => {
+      //       if (filename.endsWith('.ts')
+      //         || filename.endsWith('.m3u8')
+      //         || filename.endsWith('.mpd')
+      //         || filename.endsWith('.m4s')
+      //         || filename.endsWith('.tmp')) {
+      //         fs.unlinkSync(ouPath + '/' + filename);
+      //       }
+      //     });
+      //   }
+      // });
     });
   }
 


### PR DESCRIPTION
1. Added extra boolean property `hslKeep` to transcoding task object. #509
2. Dynamic transcoding config from stream arguments. For example rtmp://server-ip/live/stream?hslKeep=true