### PR TITLE
Support autoRetry for dynamic push sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,7 @@ relay: {
 ## Dynamic push
 When the local server receives a publish request.
 Automatically push the stream to the edge server.
+Use autoRetry flag to prevent relay end from edge disconnection when publisher is still alive.
 
 ```
 relay: {
@@ -662,6 +663,7 @@ relay: {
       app: 'live',
       mode: 'push',
       edge: 'rtmp://192.168.0.10',
+      autoRetry: true
     }
   ]
 }

--- a/README_CN.md
+++ b/README_CN.md
@@ -547,6 +547,7 @@ relay: {
 
 ### 动态推流
 当本地服务器收到一个发布请求，自动将这个流推送到边缘服务器。
+设置 autoRetry 为 true ，当与边缘服务器断连时，如果请求发布者依然活跃，动态推流会自动重试。
 
 ```
 relay: {
@@ -556,6 +557,7 @@ relay: {
       app: 'live',
       mode: 'push',
       edge: 'rtmp://192.168.0.10',
+      autoRetry: true
     }
   ]
 }


### PR DESCRIPTION
Usage scenario:
need to aggregate local nms video streams to a central server
&& central server sometimes would disconnect due to service upgrade
&& local nms video streams are still being transmitted continuously
&& inconvenient to ask video stream publishers to re-push streams