### PR TITLE
Add support to customize ffmpeg output options in relay and fission t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ nms.run();
 ```
 
 # Rtsp/Rtmp Relay
-NodeMediaServer implement RTSP and RTMP relay with ffmpeg.
+NodeMediaServer implements RTSP and RTMP relay with ffmpeg.
 
 ## Static pull
 The static pull mode is executed at service startup and reconnect after failure.
@@ -668,6 +668,22 @@ relay: {
 }
 ```
 
+## Transcoding Options
+FFmpeg output options could be added for the pull/push modes above. Default behavior is `-c copy`.
+```
+relay: {
+  ffmpeg: '/usr/local/bin/ffmpeg',
+  tasks: [
+    {
+      app: 'live',
+      mode: 'push',
+      options: ['-vf', 'scale=1920:-1', '-c:v', 'libx264', '-b:v', '2m', '-c:a', 'copy'],
+      edge: 'rtmp://192.168.0.10',
+    }
+  ]
+}
+```
+
 # Fission
 Real-time transcoding multi-resolution output
 ![fission](https://raw.githubusercontent.com/illuspas/resources/master/img/admin_panel_fission.png)
@@ -721,6 +737,29 @@ fission: {
         },
       ]
     },
+  ]
+}
+```
+
+## Custom Transcoding Options
+Custom FFmpeg output options could be specified directly. In this case, a suffix should also be provided for the transcoded stream.
+```
+fission: {
+  ffmpeg: '/usr/local/bin/ffmpeg',
+  tasks: [
+    {
+      rule: 'live/*',
+      model: [
+        {
+          options: ['-c:v', 'hevc_nvenc', '-b:v', '10m', '-vf', 'scale=3840:-1', '-c:a', 'copy'],
+          suffix: 'uhd5'
+        },
+        {
+          options: ['-c:v', 'libx264', '-b:v', '4m', '-vf', 'scale=1920:-1', '-c:a', 'copy'],
+          suffix: 'hd4'
+        }
+      ]
+    }
   ]
 }
 ```

--- a/README_CN.md
+++ b/README_CN.md
@@ -562,6 +562,22 @@ relay: {
 }
 ```
 
+## 转码选项
+可以为上面的推流和拉流模式配置FFmpeg输出选项。默认值是 `-c copy`.
+```
+relay: {
+  ffmpeg: '/usr/local/bin/ffmpeg',
+  tasks: [
+    {
+      app: 'live',
+      mode: 'push',
+      options: ['-vf', 'scale=1920:-1', '-c:v', 'libx264', '-b:v', '2m', '-c:a', 'copy'],
+      edge: 'rtmp://192.168.0.10',
+    }
+  ]
+}
+```
+
 # 实时多分辨率转码
 ![fission](https://raw.githubusercontent.com/illuspas/resources/master/img/admin_panel_fission.png)
 ```
@@ -614,6 +630,29 @@ fission: {
         },
       ]
     },
+  ]
+}
+```
+
+## 自定义FFmpeg选项
+可以直接配置FFmpeg输出选项，同时需要为转码后的流设置后缀。
+```
+fission: {
+  ffmpeg: '/usr/local/bin/ffmpeg',
+  tasks: [
+    {
+      rule: 'live/*',
+      model: [
+        {
+          options: ['-c:v', 'hevc_nvenc', '-b:v', '10m', '-vf', 'scale=3840:-1', '-c:a', 'copy'],
+          suffix: 'uhd5'
+        },
+        {
+          options: ['-c:v', 'libx264', '-b:v', '4m', '-vf', 'scale=1920:-1', '-c:a', 'copy'],
+          suffix: 'hd4'
+        }
+      ]
+    }
   ]
 }
 ```

--- a/src/api/controllers/relay.js
+++ b/src/api/controllers/relay.js
@@ -31,6 +31,7 @@ function getStreams(req, res, next) {
     stats[app][name]['relays'].push({
       app: app,
       name: name,
+      options: session.conf.options,
       path: session.conf.inPath,
       url: session.conf.ouPath,
       mode: session.conf.mode,
@@ -56,6 +57,7 @@ function getStreamByID(req, res, next) {
   const relays = relaySession.map((item) => ({
     app: item.conf.app,
     name: item.conf.name,
+    options: item.conf.options,
     path: item.conf.inPath,
     url: item.conf.ouPath,
     mode: item.conf.mode,
@@ -81,6 +83,7 @@ function getStreamByName(req, res, next) {
   const relays = relaySession.map((item) => ({
     app: item.conf.app,
     name: item.conf.name,
+    options: item.conf.options,
     url: item.conf.ouPath,
     mode: item.conf.mode,
     ts: item.ts,
@@ -118,9 +121,10 @@ async function pullStream(req, res, next) {
   let url = req.body.url;
   let app = req.body.app;
   let name = req.body.name;
+  let options = req.body.options ? req.body.options : null;
   let rtsp_transport = req.body.rtsp_transport ? req.body.rtsp_transport : null;
   if (url && app && name) {
-    process.nextTick(() => this.nodeEvent.emit('relayPull', url, app, name, rtsp_transport));
+    process.nextTick(() => this.nodeEvent.emit('relayPull', url, app, name, options, rtsp_transport));
     let ret = await once(this.nodeEvent, 'relayPullDone');
     res.send(ret[0]);
 
@@ -139,8 +143,9 @@ async function pushStream(req, res, next) {
   let url = req.body.url;
   let app = req.body.app;
   let name = req.body.name;
+  let options = req.body.options ? req.body.options : null;
   if (url && app && name) {
-    process.nextTick(() => this.nodeEvent.emit('relayPush', url, app, name));
+    process.nextTick(() => this.nodeEvent.emit('relayPush', url, app, name, options));
     let ret = await once(this.nodeEvent, 'relayPushDone');
     res.send(ret[0]);
   } else {

--- a/src/node_fission_server.js
+++ b/src/node_fission_server.js
@@ -65,7 +65,7 @@ class NodeFissionServer {
         conf.streamApp = app;
         conf.streamName = name;
         conf.args = args;
-        let session = new NodeFissionSession(conf);
+        let session = new NodeFissionSession(id, conf);
         this.fissionSessions.set(id, session);
         session.on('end', () => {
           this.fissionSessions.delete(id);

--- a/src/node_relay_server.js
+++ b/src/node_relay_server.js
@@ -98,10 +98,11 @@ class NodeRelayServer {
   }
 
   //从远端拉推到本地
-  onRelayPull(url, app, name, rtsp_transport) {
+  onRelayPull(url, app, name, options, rtsp_transport) {
     let conf = {};
     conf.app = app;
     conf.name = name;
+    conf.options = options;
     conf.mode = 'pull';
     conf.ffmpeg = this.config.relay.ffmpeg;
     conf.inPath = url;
@@ -124,10 +125,11 @@ class NodeRelayServer {
   }
 
   //从本地拉推到远端
-  onRelayPush(url, app, name) {
+  onRelayPush(url, app, name, options) {
     let conf = {};
     conf.app = app;
     conf.name = name;
+    conf.options = options;
     conf.mode = 'push';
     conf.ffmpeg = this.config.relay.ffmpeg;
     conf.inPath = `rtmp://127.0.0.1:${this.config.rtmp.port}/${app}/${name}`;

--- a/src/node_relay_session.js
+++ b/src/node_relay_session.js
@@ -22,7 +22,8 @@ class NodeRelaySession extends EventEmitter {
 
   run() {
     let format = this.conf.ouPath.startsWith('rtsp://') ? 'rtsp' : 'flv';
-    let argv = ['-re', '-i', this.conf.inPath, '-c', 'copy', '-f', format, this.conf.ouPath];
+    let options = this.conf.options ? this.conf.options: ['-c', 'copy'];
+    let argv = ['-re', '-i', this.conf.inPath, ...options, '-f', format, this.conf.ouPath];
     if (this.conf.inPath[0] === '/' || this.conf.inPath[1] === ':') {
       argv.unshift('-1');
       argv.unshift('-stream_loop');


### PR DESCRIPTION
Currently FFmpeg output options are hardcoded to `-c copy` for relay tasks and libx264 for fission tasks.

This PR add support to customize FFmpeg output options for these tasks. Thus FFmpeg filters, transcodings can be configured for advanced usage.