### PR TITLE
fix: empty appname on init and instead use 'live' as default

### DIFF
--- a/src/node_rtmp_session.js
+++ b/src/node_rtmp_session.js
@@ -169,7 +169,7 @@ class NodeRtmpSession {
     this.inAckSize = 0;
     this.inLastAck = 0;
 
-    this.appname = '';
+    this.appname = config.appname || "live";
     this.streams = 0;
 
     this.playStreamId = 0;


### PR DESCRIPTION
#447

Empty `appname` is causing the stream publish to `http://localhost:8000//stream.flv` instead of http://localhost:8000/live/stream.flv` as the doc suggest

Not tested!