### PR TITLE
fix: flv_session sendBuffer, check writableEnded before write

### DIFF
--- a/src/session/flv_session.js
+++ b/src/session/flv_session.js
@@ -115,6 +115,7 @@ class FlvSession extends BaseSession {
    */
   sendBuffer = (buffer) => {
     this.outBytes += buffer.length;
+    if(this.res.writableEnded) return
     this.res.write(buffer);
   };
 


### PR DESCRIPTION
```js
this.nms = new NodeMediaServer(config);
this.nms.on('postPlay', (session)=>{
  // todo verify ...
  if (...) {
    session.close() // error
  }
});
```